### PR TITLE
Enabled Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+    target-branch: "develop"
+    reviewers:
+      - "jrsaruo"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -17,6 +17,9 @@ changelog:
       labels:
         - documentation
         - maintenance
+    - title: ⬆️ Dependencies
+      labels:
+        - dependencies
     - title: Other Changes
       labels:
         - "*"


### PR DESCRIPTION
# Maintenance

- Enabled Dependabot for GitHub Actions.
- Added Dependencies section to the release note template.