### PR TITLE
Supported Xcode 14

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ AceLayout provides a Swifty DSL for Auto Layout.
 ## Requirements
 
 - iOS 9.0+ / macOS 10.11+ / tvOS 9.0+
-- Xcode 13+
-- Swift 5.5+
+- Xcode 14+
+- Swift 5.7+
 
 ## Features
 

--- a/Sources/AceLayout/Extensions/NSLayoutConstraint+Extension.swift
+++ b/Sources/AceLayout/Extensions/NSLayoutConstraint+Extension.swift
@@ -23,7 +23,7 @@ extension NSLayoutConstraint {
     }
 }
 
-extension Sequence where Element: NSLayoutConstraint {
+extension Sequence<NSLayoutConstraint> {
     
     /// Updates each constraint with the specified `priority`.
     /// - Parameter priority: The layout priority.

--- a/Sources/AceLayout/LayoutAnchors/BaselineAnchor.swift
+++ b/Sources/AceLayout/LayoutAnchors/BaselineAnchor.swift
@@ -14,7 +14,7 @@ import AppKit
 /// A type that represents a baseline layout anchor for creating vertical layout constraints.
 public protocol BaselineAnchor: LayoutAnchor where AnchorType == NSLayoutYAxisAnchor,
                                                    BaseLayoutAnchor == NSLayoutYAxisAnchor,
-                                                   Target == BaselinesConstrainable {}
+                                                   Target == any BaselinesConstrainable {}
 
 extension BaselineAnchor {
     

--- a/Sources/AceLayout/LayoutAnchors/BaselineAnchor.swift
+++ b/Sources/AceLayout/LayoutAnchors/BaselineAnchor.swift
@@ -34,8 +34,8 @@ extension BaselineAnchor {
     ///   - offset: A constant offset for the constraint. The default value is `0`.
     /// - Returns: An  `NSLayoutConstraint` object that represents `self` baseline == `another` baseline + `offset`.
     @inlinable
-    public func equal<Another>(to another: Another,
-                               plus offset: CGFloat = 0) -> NSLayoutConstraint where Another: BaselinesConstrainable {
+    public func equal(to another: some BaselinesConstrainable,
+                      plus offset: CGFloat = 0) -> NSLayoutConstraint {
         anchor.constraint(equalTo: another[keyPath: anchorKeyPath], constant: offset)
     }
     
@@ -53,8 +53,8 @@ extension BaselineAnchor {
     ///   - offset: A constant offset for the constraint. The default value is `0`.
     /// - Returns: An  `NSLayoutConstraint` object that represents `self` baseline <= `another` baseline + `offset`.
     @inlinable
-    public func lessThanOrEqual<Another>(to another: Another,
-                                         plus offset: CGFloat = 0) -> NSLayoutConstraint where Another: BaselinesConstrainable {
+    public func lessThanOrEqual(to another: some BaselinesConstrainable,
+                                plus offset: CGFloat = 0) -> NSLayoutConstraint {
         anchor.constraint(lessThanOrEqualTo: another[keyPath: anchorKeyPath], constant: offset)
     }
     
@@ -72,8 +72,8 @@ extension BaselineAnchor {
     ///   - offset: A constant offset for the constraint. The default value is `0`.
     /// - Returns: An  `NSLayoutConstraint` object that represents `self` baseline >= `another` baseline + `offset`.
     @inlinable
-    public func greaterThanOrEqual<Another>(to another: Another,
-                                            plus offset: CGFloat = 0) -> NSLayoutConstraint where Another: BaselinesConstrainable {
+    public func greaterThanOrEqual(to another: some BaselinesConstrainable,
+                                   plus offset: CGFloat = 0) -> NSLayoutConstraint {
         anchor.constraint(greaterThanOrEqualTo: another[keyPath: anchorKeyPath], constant: offset)
     }
     

--- a/Sources/AceLayout/LayoutAnchors/LayoutDimension.swift
+++ b/Sources/AceLayout/LayoutAnchors/LayoutDimension.swift
@@ -14,7 +14,7 @@ import AppKit
 /// A type that represents a layout anchor for creating size-based layout constraints.
 public protocol LayoutDimension: LayoutAnchor where AnchorType == NSLayoutDimension,
                                                     BaseLayoutAnchor == NSLayoutDimension,
-                                                    Target == SizeConstrainable {}
+                                                    Target == any SizeConstrainable {}
 
 extension LayoutDimension {
     

--- a/Sources/AceLayout/LayoutAnchors/LayoutDimension.swift
+++ b/Sources/AceLayout/LayoutAnchors/LayoutDimension.swift
@@ -37,8 +37,8 @@ extension LayoutDimension {
     ///   - offset: A constant offset for the constraint. The default value is `0`.
     /// - Returns: An  `NSLayoutConstraint` object that represents `self` dimension == `another` dimension + `offset`.
     @inlinable
-    public func equal<Another>(to another: Another,
-                               plus offset: CGFloat = 0) -> NSLayoutConstraint where Another: SizeConstrainable {
+    public func equal(to another: some SizeConstrainable,
+                      plus offset: CGFloat = 0) -> NSLayoutConstraint {
         anchor.constraint(equalTo: another[keyPath: anchorKeyPath], constant: offset)
     }
     
@@ -59,8 +59,8 @@ extension LayoutDimension {
     ///   - offset: A constant offset for the constraint. The default value is `0`.
     /// - Returns: An  `NSLayoutConstraint` object that represents `self` dimension <= `another` dimension + `offset`.
     @inlinable
-    public func lessThanOrEqual<Another>(to another: Another,
-                                         plus offset: CGFloat = 0) -> NSLayoutConstraint where Another: SizeConstrainable {
+    public func lessThanOrEqual(to another: some SizeConstrainable,
+                                plus offset: CGFloat = 0) -> NSLayoutConstraint {
         anchor.constraint(lessThanOrEqualTo: another[keyPath: anchorKeyPath], constant: offset)
     }
     
@@ -81,8 +81,8 @@ extension LayoutDimension {
     ///   - offset: A constant offset for the constraint. The default value is `0`.
     /// - Returns: An  `NSLayoutConstraint` object that represents `self` dimension >= `another` dimension + `offset`.
     @inlinable
-    public func greaterThanOrEqual<Another>(to another: Another,
-                                            plus offset: CGFloat = 0) -> NSLayoutConstraint where Another: SizeConstrainable {
+    public func greaterThanOrEqual(to another: some SizeConstrainable,
+                                   plus offset: CGFloat = 0) -> NSLayoutConstraint {
         anchor.constraint(greaterThanOrEqualTo: another[keyPath: anchorKeyPath], constant: offset)
     }
     
@@ -100,8 +100,8 @@ extension LayoutDimension {
     ///   - multiplier: The multiplier constant for the constraint.
     /// - Returns: An  `NSLayoutConstraint` object that represents `self` dimension == `another` dimension \* `multiplier`.
     @inlinable
-    public func equal<Another>(to another: Another,
-                               multipliedBy multiplier: CGFloat) -> NSLayoutConstraint where Another: SizeConstrainable {
+    public func equal(to another: some SizeConstrainable,
+                      multipliedBy multiplier: CGFloat) -> NSLayoutConstraint {
         anchor.constraint(equalTo: another[keyPath: anchorKeyPath], multiplier: multiplier)
     }
     
@@ -119,8 +119,8 @@ extension LayoutDimension {
     ///   - multiplier: The multiplier constant for the constraint.
     /// - Returns: An  `NSLayoutConstraint` object that represents `self` dimension <= `another` dimension \* `multiplier`.
     @inlinable
-    public func lessThanOrEqual<Another>(to another: Another,
-                                         multipliedBy multiplier: CGFloat) -> NSLayoutConstraint where Another: SizeConstrainable {
+    public func lessThanOrEqual(to another: some SizeConstrainable,
+                                multipliedBy multiplier: CGFloat) -> NSLayoutConstraint {
         anchor.constraint(lessThanOrEqualTo: another[keyPath: anchorKeyPath], multiplier: multiplier)
     }
     
@@ -138,8 +138,8 @@ extension LayoutDimension {
     ///   - multiplier: The multiplier constant for the constraint.
     /// - Returns: An  `NSLayoutConstraint` object that represents `self` dimension >= `another` dimension \* `multiplier`.
     @inlinable
-    public func greaterThanOrEqual<Another>(to another: Another,
-                                            multipliedBy multiplier: CGFloat) -> NSLayoutConstraint where Another: SizeConstrainable {
+    public func greaterThanOrEqual(to another: some SizeConstrainable,
+                                   multipliedBy multiplier: CGFloat) -> NSLayoutConstraint {
         anchor.constraint(greaterThanOrEqualTo: another[keyPath: anchorKeyPath], multiplier: multiplier)
     }
     

--- a/Sources/AceLayout/LayoutAnchors/LayoutRect.swift
+++ b/Sources/AceLayout/LayoutAnchors/LayoutRect.swift
@@ -68,8 +68,8 @@ extension LayoutRect {
         ///   - another: An instance of the type that conforms to ``XYAxesConstrainable`` protocol such as `UIView`, `UILayoutGuide`, `NSView` or `NSLayoutGuide`.
         ///   - offset: A constant offset for the constraint. The default value is `.zero`.
         /// - Returns: An  `NSLayoutConstraint` object that represents `self` point == `another` point shifted by `offset`.
-        public func equal<Another>(to another: Another,
-                                   shiftedBy offset: CGSize = .zero) -> [NSLayoutConstraint] where Another: XYAxesConstrainable {
+        public func equal(to another: some XYAxesConstrainable,
+                          shiftedBy offset: CGSize = .zero) -> [NSLayoutConstraint] {
             [
                 x.equal(to: another, plus: offset.width),
                 y.equal(to: another, plus: offset.height)
@@ -95,8 +95,8 @@ extension LayoutRect {
         ///   - another: An instance of the type that conforms to ``XYAxesConstrainable`` protocol such as `UIView`, `UILayoutGuide`, `NSView` or `NSLayoutGuide`.
         ///   - offset: A constant offset for the constraint. The default value is `.zero`.
         /// - Returns: An  `NSLayoutConstraint` object that represents `self` point <= `another` point shifted by `offset`.
-        public func lessThanOrEqual<Another>(to another: Another,
-                                             shiftedBy offset: CGSize = .zero) -> [NSLayoutConstraint] where Another: XYAxesConstrainable {
+        public func lessThanOrEqual(to another: some XYAxesConstrainable,
+                                    shiftedBy offset: CGSize = .zero) -> [NSLayoutConstraint] {
             [
                 x.lessThanOrEqual(to: another, plus: offset.width),
                 y.lessThanOrEqual(to: another, plus: offset.height)
@@ -122,8 +122,8 @@ extension LayoutRect {
         ///   - another: An instance of the type that conforms to ``XYAxesConstrainable`` protocol such as `UIView`, `UILayoutGuide`, `NSView` or `NSLayoutGuide`.
         ///   - offset: A constant offset for the constraint. The default value is `.zero`.
         /// - Returns: An  `NSLayoutConstraint` object that represents `self` point >= `another` point shifted by `offset`.
-        public func greaterThanOrEqual<Another>(to another: Another,
-                                                shiftedBy offset: CGSize = .zero) -> [NSLayoutConstraint] where Another: XYAxesConstrainable {
+        public func greaterThanOrEqual(to another: some XYAxesConstrainable,
+                                       shiftedBy offset: CGSize = .zero) -> [NSLayoutConstraint] {
             [
                 x.greaterThanOrEqual(to: another, plus: offset.width),
                 y.greaterThanOrEqual(to: another, plus: offset.height)
@@ -231,8 +231,8 @@ extension LayoutRect {
         ///   - another: An instance of the type that conforms to ``SizeConstrainable`` protocol such as `UIView`, `UILayoutGuide`, `NSView` or `NSLayoutGuide`.
         ///   - multiplier: The multiplier constant for the constraint. The default value is `1`.
         /// - Returns: An  `NSLayoutConstraint` object that represents `self` size == `another` size \* `multiplier`.
-        public func equal<Another>(to another: Another,
-                                   multipliedBy multiplier: CGFloat = 1) -> [NSLayoutConstraint] where Another: SizeConstrainable {
+        public func equal(to another: some SizeConstrainable,
+                          multipliedBy multiplier: CGFloat = 1) -> [NSLayoutConstraint] {
             [
                 width.equal(to: another, multipliedBy: multiplier),
                 height.equal(to: another, multipliedBy: multiplier)
@@ -256,8 +256,8 @@ extension LayoutRect {
         ///   - another: An instance of the type that conforms to ``SizeConstrainable`` protocol such as `UIView`, `UILayoutGuide`, `NSView` or `NSLayoutGuide`.
         ///   - multiplier: The multiplier constant for the constraint. The default value is `1`.
         /// - Returns: An  `NSLayoutConstraint` object that represents `self` size <= `another` size \* `multiplier`.
-        public func lessThanOrEqual<Another>(to another: Another,
-                                             multipliedBy multiplier: CGFloat = 1) -> [NSLayoutConstraint] where Another: SizeConstrainable {
+        public func lessThanOrEqual(to another: some SizeConstrainable,
+                                    multipliedBy multiplier: CGFloat = 1) -> [NSLayoutConstraint] {
             [
                 width.lessThanOrEqual(to: another, multipliedBy: multiplier),
                 height.lessThanOrEqual(to: another, multipliedBy: multiplier)
@@ -281,8 +281,8 @@ extension LayoutRect {
         ///   - another: An instance of the type that conforms to ``SizeConstrainable`` protocol such as `UIView`, `UILayoutGuide`, `NSView` or `NSLayoutGuide`.
         ///   - multiplier: The multiplier constant for the constraint. The default value is `1`.
         /// - Returns: An  `NSLayoutConstraint` object that represents `self` size >= `another` size \* `multiplier`.
-        public func greaterThanOrEqual<Another>(to another: Another,
-                                                multipliedBy multiplier: CGFloat = 1) -> [NSLayoutConstraint] where Another: SizeConstrainable {
+        public func greaterThanOrEqual(to another: some SizeConstrainable,
+                                       multipliedBy multiplier: CGFloat = 1) -> [NSLayoutConstraint] {
             [
                 width.greaterThanOrEqual(to: another, multipliedBy: multiplier),
                 height.greaterThanOrEqual(to: another, multipliedBy: multiplier)
@@ -504,8 +504,8 @@ extension LayoutRect {
         ///   - another: An instance of the type that conforms to ``XAxesConstrainable`` protocol such as `UIView`, `UILayoutGuide`, `NSView` or `NSLayoutGuide`.
         ///   - inset: A constant edge inset for the constraint. The default value is `0`.
         /// - Returns: An  `NSLayoutConstraint` object that represents `self` horizontal edges == `another` ones adjusted by `inset`.
-        public func equal<Another>(to another: Another,
-                                   insetBy inset: CGFloat = 0) -> [NSLayoutConstraint] where Another: XAxesConstrainable {
+        public func equal(to another: some XAxesConstrainable,
+                          insetBy inset: CGFloat = 0) -> [NSLayoutConstraint] {
             [
                 left.equal(to: another, plus: inset),
                 right.equal(to: another, plus: -inset)
@@ -526,8 +526,8 @@ extension LayoutRect {
         ///   - another: An instance of the type that conforms to ``XAxesConstrainable`` protocol such as `UIView`, `UILayoutGuide`, `NSView` or `NSLayoutGuide`.
         ///   - insets: A constant edge insets for the constraint. The default value is `0`.
         /// - Returns: An  `NSLayoutConstraint` object that represents `self` horizontal edges are inside of `another` ones adjusted by `inset`.
-        public func insideOrEqual<Another>(to another: Another,
-                                           insetBy inset: CGFloat = 0) -> [NSLayoutConstraint] where Another: XAxesConstrainable {
+        public func insideOrEqual(to another: some XAxesConstrainable,
+                                  insetBy inset: CGFloat = 0) -> [NSLayoutConstraint] {
             [
                 left.greaterThanOrEqual(to: another, plus: inset),
                 right.lessThanOrEqual(to: another, plus: -inset)
@@ -594,8 +594,8 @@ extension LayoutRect {
         ///   - another: An instance of the type that conforms to ``YAxesConstrainable`` protocol such as `UIView`, `UILayoutGuide`, `NSView` or `NSLayoutGuide`.
         ///   - inset: A constant edge inset for the constraint.
         /// - Returns: An  `NSLayoutConstraint` object that represents `self` vertical edges == `another` ones adjusted by `inset`.
-        public func equal<Another>(to another: Another,
-                                   insetBy inset: CGFloat = 0) -> [NSLayoutConstraint] where Another: YAxesConstrainable {
+        public func equal(to another: some YAxesConstrainable,
+                          insetBy inset: CGFloat = 0) -> [NSLayoutConstraint] {
             [
                 top.equal(to: another, plus: inset),
                 bottom.equal(to: another, plus: -inset)
@@ -615,8 +615,8 @@ extension LayoutRect {
         ///   - another: An instance of the type that conforms to ``YAxesConstrainable`` protocol such as `UIView`, `UILayoutGuide`, `NSView` or `NSLayoutGuide`.
         ///   - insets: A constant edge insets for the constraint. The default value is `0`.
         /// - Returns: An  `NSLayoutConstraint` object that represents `self` vertical edges are inside of `another` ones adjusted by `inset`.
-        public func insideOrEqual<Another>(to another: Another,
-                                           insetBy inset: CGFloat = 0) -> [NSLayoutConstraint] where Another: YAxesConstrainable {
+        public func insideOrEqual(to another: some YAxesConstrainable,
+                                  insetBy inset: CGFloat = 0) -> [NSLayoutConstraint] {
             [
                 top.greaterThanOrEqual(to: another, plus: inset),
                 bottom.lessThanOrEqual(to: another, plus: -inset)
@@ -693,8 +693,8 @@ extension LayoutRect {
         ///   - another: An instance of the type that conforms to ``XYAxesConstrainable`` protocol such as `UIView`, `UILayoutGuide`, `NSView` or `NSLayoutGuide`.
         ///   - insets: A constant edge insets for the constraint. The default value is `.zero`.
         /// - Returns: An  `NSLayoutConstraint` object that represents `self` edges == `another` edges adjusted by `insets`.
-        public func equal<Another>(to another: Another,
-                                   insetBy insets: AL.EdgeInsets = .zero) -> [NSLayoutConstraint] where Another: XYAxesConstrainable {
+        public func equal(to another: some XYAxesConstrainable,
+                          insetBy insets: AL.EdgeInsets = .zero) -> [NSLayoutConstraint] {
             [
                 top.equal(to: another, plus: insets.top),
                 left.equal(to: another, plus: insets.left),
@@ -720,8 +720,8 @@ extension LayoutRect {
         ///   - inset: A constant edge inset for the constraint.
         /// - Returns: An  `NSLayoutConstraint` object that represents `self` edges == `another` edges adjusted by `inset`.
         @inlinable
-        public func equal<Another>(to another: Another,
-                                   insetBy inset: CGFloat) -> [NSLayoutConstraint] where Another: XYAxesConstrainable {
+        public func equal(to another: some XYAxesConstrainable,
+                          insetBy inset: CGFloat) -> [NSLayoutConstraint] {
             equal(to: another, insetBy: .init(top: inset, left: inset, bottom: inset, right: inset))
         }
         
@@ -748,8 +748,8 @@ extension LayoutRect {
         ///   - another: An instance of the type that conforms to ``XYAxesConstrainable`` protocol such as `UIView`, `UILayoutGuide`, `NSView` or `NSLayoutGuide`.
         ///   - insets: A constant edge insets for the constraint. The default value is `.zero`.
         /// - Returns: An  `NSLayoutConstraint` object that represents `self` edges are inside of `another` edges adjusted by `insets`.
-        public func insideOrEqual<Another>(to another: Another,
-                                           insetBy insets: AL.EdgeInsets = .zero) -> [NSLayoutConstraint] where Another: XYAxesConstrainable {
+        public func insideOrEqual(to another: some XYAxesConstrainable,
+                                  insetBy insets: AL.EdgeInsets = .zero) -> [NSLayoutConstraint] {
             [
                 top.greaterThanOrEqual(to: another, plus: insets.top),
                 left.greaterThanOrEqual(to: another, plus: insets.left),
@@ -775,8 +775,8 @@ extension LayoutRect {
         ///   - inset: A constant edge inset for the constraint.
         /// - Returns: An  `NSLayoutConstraint` object that represents `self` edges are inside of `another` edges adjusted by `inset`.
         @inlinable
-        public func insideOrEqual<Another>(to another: Another,
-                                           insetBy inset: CGFloat) -> [NSLayoutConstraint] where Another: XYAxesConstrainable {
+        public func insideOrEqual(to another: some XYAxesConstrainable,
+                                  insetBy inset: CGFloat) -> [NSLayoutConstraint] {
             insideOrEqual(to: another, insetBy: .init(top: inset, left: inset, bottom: inset, right: inset))
         }
         

--- a/Sources/AceLayout/LayoutAnchors/XAxisAnchor.swift
+++ b/Sources/AceLayout/LayoutAnchors/XAxisAnchor.swift
@@ -37,8 +37,8 @@ extension XAxisAnchor {
     ///   - offset: A constant offset for the constraint. The default value is `0`.
     /// - Returns: An  `NSLayoutConstraint` object that represents `self` x == `another` x + `offset`.
     @inlinable
-    public func equal<Another>(to another: Another,
-                               plus offset: CGFloat = 0) -> NSLayoutConstraint where Another: XAxesConstrainable {
+    public func equal(to another: some XAxesConstrainable,
+                      plus offset: CGFloat = 0) -> NSLayoutConstraint {
         anchor.constraint(equalTo: another[keyPath: anchorKeyPath], constant: offset)
     }
     
@@ -59,8 +59,8 @@ extension XAxisAnchor {
     ///   - offset: A constant offset for the constraint. The default value is `0`.
     /// - Returns: An  `NSLayoutConstraint` object that represents `self` x <= `another` x + `offset`.
     @inlinable
-    public func lessThanOrEqual<Another>(to another: Another,
-                                         plus offset: CGFloat = 0) -> NSLayoutConstraint where Another: XAxesConstrainable {
+    public func lessThanOrEqual(to another: some XAxesConstrainable,
+                                plus offset: CGFloat = 0) -> NSLayoutConstraint {
         anchor.constraint(lessThanOrEqualTo: another[keyPath: anchorKeyPath], constant: offset)
     }
     
@@ -81,8 +81,8 @@ extension XAxisAnchor {
     ///   - offset: A constant offset for the constraint. The default value is `0`.
     /// - Returns: An  `NSLayoutConstraint` object that represents `self` x >= `another` x + `offset`.
     @inlinable
-    public func greaterThanOrEqual<Another>(to another: Another,
-                                            plus offset: CGFloat = 0) -> NSLayoutConstraint where Another: XAxesConstrainable {
+    public func greaterThanOrEqual(to another: some XAxesConstrainable,
+                                   plus offset: CGFloat = 0) -> NSLayoutConstraint {
         anchor.constraint(greaterThanOrEqualTo: another[keyPath: anchorKeyPath], constant: offset)
     }
     

--- a/Sources/AceLayout/LayoutAnchors/XAxisAnchor.swift
+++ b/Sources/AceLayout/LayoutAnchors/XAxisAnchor.swift
@@ -14,7 +14,7 @@ import AppKit
 /// A type that represents a layout anchor for creating horizontal layout constraints.
 public protocol XAxisAnchor: LayoutAnchor where AnchorType == NSLayoutXAxisAnchor,
                                                 BaseLayoutAnchor == NSLayoutXAxisAnchor,
-                                                Target == XAxesConstrainable {}
+                                                Target == any XAxesConstrainable {}
 
 extension XAxisAnchor {
     

--- a/Sources/AceLayout/LayoutAnchors/YAxisAnchor.swift
+++ b/Sources/AceLayout/LayoutAnchors/YAxisAnchor.swift
@@ -14,7 +14,7 @@ import AppKit
 /// A type that represents a layout anchor for creating vertical layout constraints.
 public protocol YAxisAnchor: LayoutAnchor where AnchorType == NSLayoutYAxisAnchor,
                                                 BaseLayoutAnchor == NSLayoutYAxisAnchor,
-                                                Target == YAxesConstrainable {}
+                                                Target == any YAxesConstrainable {}
 
 extension YAxisAnchor {
     

--- a/Sources/AceLayout/LayoutAnchors/YAxisAnchor.swift
+++ b/Sources/AceLayout/LayoutAnchors/YAxisAnchor.swift
@@ -37,8 +37,8 @@ extension YAxisAnchor {
     ///   - offset: A constant offset for the constraint. The default value is `0`.
     /// - Returns: An  `NSLayoutConstraint` object that represents `self` y == `another` y + `offset`.
     @inlinable
-    public func equal<Another>(to another: Another,
-                               plus offset: CGFloat = 0) -> NSLayoutConstraint where Another: YAxesConstrainable {
+    public func equal(to another: some YAxesConstrainable,
+                      plus offset: CGFloat = 0) -> NSLayoutConstraint {
         anchor.constraint(equalTo: another[keyPath: anchorKeyPath], constant: offset)
     }
     
@@ -59,8 +59,8 @@ extension YAxisAnchor {
     ///   - offset: A constant offset for the constraint. The default value is `0`.
     /// - Returns: An  `NSLayoutConstraint` object that represents `self` y <= `another` y + `offset`.
     @inlinable
-    public func lessThanOrEqual<Another>(to another: Another,
-                                         plus offset: CGFloat = 0) -> NSLayoutConstraint where Another: YAxesConstrainable {
+    public func lessThanOrEqual(to another: some YAxesConstrainable,
+                                plus offset: CGFloat = 0) -> NSLayoutConstraint {
         anchor.constraint(lessThanOrEqualTo: another[keyPath: anchorKeyPath], constant: offset)
     }
     
@@ -81,8 +81,8 @@ extension YAxisAnchor {
     ///   - offset: A constant offset for the constraint. The default value is `0`.
     /// - Returns: An  `NSLayoutConstraint` object that represents `self` y >= `another` y + `offset`.
     @inlinable
-    public func greaterThanOrEqual<Another>(to another: Another,
-                                            plus offset: CGFloat = 0) -> NSLayoutConstraint where Another: YAxesConstrainable {
+    public func greaterThanOrEqual(to another: some YAxesConstrainable,
+                                   plus offset: CGFloat = 0) -> NSLayoutConstraint {
         anchor.constraint(greaterThanOrEqualTo: another[keyPath: anchorKeyPath], constant: offset)
     }
     

--- a/Sources/AceLayout/LayoutTarget.swift
+++ b/Sources/AceLayout/LayoutTarget.swift
@@ -14,8 +14,8 @@ import AppKit
 /// A type that represents layout target such as `UIView`, `UILayoutGuide`, `NSView` or `NSLayoutGuide`.
 public protocol LayoutTarget {
     /// A type that represents layout target such as `UIView`, `UILayoutGuide`, `NSView` or `NSLayoutGuide`.
-    /// This is equal to `Self`.
-    associatedtype LayoutBase where LayoutBase == Self
+    /// This is typically equal to `LayoutTarget` itself.
+    associatedtype LayoutBase
     
     func autoLayout(activates: Bool,
                     @LayoutConstraintsBuilder builder: (LayoutItem<LayoutBase>) -> [NSLayoutConstraint]) -> [NSLayoutConstraint]


### PR DESCRIPTION
# Maintenance

- Resolved the warning for Swift 6.
- Marked existential types with `any`.
- Improved to use syntax sugar.